### PR TITLE
pr 생성 시, 연결된 task popup url 변경

### DIFF
--- a/github.js
+++ b/github.js
@@ -54,7 +54,7 @@ function applyDoorayInfo(responseText) {
   ).value = `#${projectName}/${content.number}: ${content.subject}`;
   document.querySelector(
     "textarea[id=pull_request_body]"
-  ).value = `* https://nhnent.dooray.com/popup/project/posts/${
+  ).value = `* https://nhnent.dooray.com/task/view/tasks/${
     content.id
   }`;
 }


### PR DESCRIPTION
아래 2가지 이유 때문에 수정하여 pr 드립니다.

1. 현재 pr 생성 시 자동으로 추가되는 테스크 popup url 은 구버전 두레이입니다
2. popup 으로 뜬 테스크의 상태를 수정해도 실제 테스크의 상태가 변경되지 않습니다.

혹시 구버전 두레이를 이용하시는 이유가 있으시다면, 코멘트 남겨주시면 이 pr 은 close 처리 하도록 하겠습니다.